### PR TITLE
CP-1099 Add close() to client. Add integration tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .project
-packages
 
+.packages
+.pub
+packages
+pubspec.lock

--- a/lib/sockjs_client.dart
+++ b/lib/sockjs_client.dart
@@ -1,6 +1,6 @@
 library sockjs_client;
 
-import "dart:html";
+import "dart:html" as html;
 import "dart:convert";
 import "dart:async";
 import "dart:js";

--- a/lib/src/ajax.dart
+++ b/lib/src/ajax.dart
@@ -10,7 +10,7 @@ typedef AbstractXHRObject AjaxObjectFactory(String method, String baseUrl, [payl
 
 class AbstractXHRObject extends Object with event.Emitter {
 
-  HttpRequest xhr;
+  html.HttpRequest xhr;
   StreamSubscription changeSubscription;
 
   Stream get onChunk => this["chunk"];
@@ -20,7 +20,7 @@ class AbstractXHRObject extends Object with event.Emitter {
   _start(method, url, payload, {noCredentials: false, headers}) {
 
     try {
-        xhr = new HttpRequest();
+        xhr = new html.HttpRequest();
     } catch(x) {};
 
     if ( xhr == null ) {
@@ -61,7 +61,7 @@ class AbstractXHRObject extends Object with event.Emitter {
     xhr.send(payload);
   }
 
-  _readyStateHandler(Event evt) {
+  _readyStateHandler(html.Event evt) {
     switch (xhr.readyState) {
       case 3:
         var text, status;

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -70,6 +70,22 @@ class Client extends Object with event.Emitter {
   Stream get onClose => this["close"];
   Stream get onHeartbeat => this["heartbeat"];
 
+  void close([int code, String reason]) {
+    if (_transport != null) {
+      if (_transport is WebSocketTransport) {
+        _transport.doClose(code, reason);
+      } else if (_transport is XhrStreamingTransport) {
+        if (code == null) {
+          code = 0;
+        }
+        if (reason == null) {
+          reason = '';
+        }
+        _didClose(code, reason);
+      }
+    }
+  }
+
   send(data) {
     if (readyState == CONNECTING) {
         throw 'INVALID_STATE_ERR';
@@ -199,11 +215,11 @@ class Client extends Object with event.Emitter {
       // the `head`?
       if (PROTOCOLS.containsKey(protocol) &&
           PROTOCOLS[protocol].needBody &&
-          ( (document.body == null) || (document.readyState != null && document.readyState != 'complete'))
+          ( (html.document.body == null) || (html.document.readyState != null && html.document.readyState != 'complete'))
           ) {
           _protocols.insert(0, protocol);
           this.protocol = 'waiting-for-load';
-          document.onLoad.listen( (_) => _tryNextProtocol());
+          html.document.onLoad.listen( (_) => _tryNextProtocol());
           return true;
       }
 

--- a/lib/src/info.dart
+++ b/lib/src/info.dart
@@ -12,7 +12,7 @@ class Info {
     origins = json["origins"];
     cookieNeeded = json["cookie_needed"];
     entropy = json["entropy"];
-    nullOrigin = (document.domain == null);
+    nullOrigin = (html.document.domain == null);
   }
 }
 
@@ -84,8 +84,8 @@ class AjaxInfoReceiver extends InfoReceiver {
 class InfoReceiverIframe extends InfoReceiver {
 
   InfoReceiverIframe(base_url) : super._() {
-    if(document.body == null) {
-      document.onLoad.listen((_) => go());
+    if(html.document.body == null) {
+      html.document.onLoad.listen((_) => go());
     } else {
         go();
     }

--- a/lib/src/transport/sender.dart
+++ b/lib/src/transport/sender.dart
@@ -66,18 +66,18 @@ class BufferedSender {
 // postMessage communication */
 class JsonPGenericSender {
 
-  FormElement _sendForm = null;
-  TextAreaElement _sendArea = null;
+  html.FormElement _sendForm = null;
+  html.TextAreaElement _sendArea = null;
 
   var completed;
 
   JsonPGenericSender(url, payload, callback) {
-    FormElement form;
-    TextAreaElement area;
+    html.FormElement form;
+    html.TextAreaElement area;
 
     if (_sendForm == null) {
-      form = _sendForm = new Element.tag('form');
-      area = _sendArea = new Element.tag('textarea');
+      form = _sendForm = new html.Element.tag('form');
+      area = _sendArea = new html.Element.tag('textarea');
       area.name = 'd';
       form.style.display = 'none';
       form.style.position = 'absolute';
@@ -93,12 +93,12 @@ class JsonPGenericSender {
     form.target = id;
     form.action = '$url/jsonp_send?i=$id';
 
-    IFrameElement iframe;
+    html.IFrameElement iframe;
     try {
         // ie6 dynamic iframes with target="" support (thanks Chris Lambacher)
-        iframe = new Element.html('<iframe name="$id">');
+        iframe = new html.Element.html('<iframe name="$id">');
     } catch(x) {
-        iframe = new Element.tag('iframe');
+        iframe = new html.Element.tag('iframe');
         iframe.name = id;
     }
     iframe.id = id;

--- a/lib/src/transport/websocket.dart
+++ b/lib/src/transport/websocket.dart
@@ -4,7 +4,7 @@ class WebSocketTransport {
   Client ri;
   String url;
 
-  WebSocket ws;
+  html.WebSocket ws;
   StreamSubscription messageSubscription;
   StreamSubscription closeSubscription;
 
@@ -20,7 +20,7 @@ class WebSocketTransport {
 
     this.url = url;
 
-    ws = new WebSocket(url);
+    ws = new html.WebSocket(url);
 
 
     messageSubscription = ws.onMessage.listen(_msgHandler);
@@ -37,7 +37,17 @@ class WebSocketTransport {
 
   _msgHandler(m) => ri._didMessage(m.data);
 
-  _closeHandler(m) => ri._didMessage(utils.closeFrame(1006, "WebSocket connection broken"));
+  _closeHandler(html.CloseEvent c) {
+    var code = c.code != null ? c.code : 1006;
+    var reason = c.reason != null ? c.reason : 'WebSocket connection broken';
+    ri._didMessage(utils.closeFrame(code, reason));
+  }
+
+  doClose([int code, String reason]) {
+    if (ws != null) {
+      ws.close(code, reason);
+    }
+  }
 
   doSend(data) => ws.send('[$data]');
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "sockjs-dart-client",
+  "version": "0.2.0",
+  "description": "A SockJS client in Dart",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/Workiva/sockjs-dart-client.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Workiva/sockjs-dart-client/issues"
+  },
+  "homepage": "https://github.com/Workiva/sockjs-dart-client",
+  "devDependencies": {
+    "http": "0.0.0",
+    "sockjs": "^0.3.15"
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,5 +8,10 @@ authors:
 dependencies:
   browser: '>=0.9.0 <1.0.0'
   logging: '>=0.9.0 <1.0.0'
+dev_dependencies:
+  coverage: '>=0.7.2'
+  dart_dev: '>=1.0.2'
+  dart_style: '>=0.2.0'
+  test: '>=0.12.5'
 environment:
   sdk: '>=1.0.0 <2.0.0'

--- a/test/sockjs_client_integration_test.dart
+++ b/test/sockjs_client_integration_test.dart
@@ -1,0 +1,104 @@
+@TestOn('browser')
+library sockjs_client.test.sockjs_client_test;
+
+import 'dart:async';
+
+import 'package:sockjs_client/sockjs_client.dart';
+import 'package:test/test.dart';
+
+const String echoUri = 'http://localhost:8000/echo';
+const String corUri = 'http://localhost:8000/cor';
+const String fofUri = 'http://localhost:8600/404';
+
+void main() {
+  group('SockJS Client', () {
+    group('default', () {
+      Client createEchoClient() => new Client(echoUri);
+      Client createCorClient() => new Client(corUri);
+      Client create404Client() => new Client(fofUri);
+
+      integrationSuite(createEchoClient, createCorClient, create404Client);
+    });
+
+    group('web-socket', () {
+      Client createEchoClient() => new Client(echoUri, protocolsWhitelist: ['websocket']);
+      Client createCorClient() => new Client(corUri, protocolsWhitelist: ['websocket']);
+      Client create404Client() => new Client(fofUri, protocolsWhitelist: ['websocket']);
+
+      integrationSuite(createEchoClient, createCorClient, create404Client);
+    });
+
+    group('xhr-streaming', () {
+      Client createEchoClient() => new Client(echoUri, protocolsWhitelist: ['xhr-streaming']);
+      Client createCorClient() => new Client(corUri, protocolsWhitelist: ['xhr-streaming']);
+      Client create404Client() => new Client(fofUri, protocolsWhitelist: ['xhr-streaming']);
+
+      integrationSuite(createEchoClient, createCorClient, create404Client);
+    });
+  });
+}
+
+void integrationSuite(Client createEchoClient(), Client createCorClient(), Client create404Client()) {
+  test('connecting to a SockJS server', () async {
+    Client client = createEchoClient();
+    await client.onOpen.first;
+  });
+
+  test('sending and receiving messages', () async {
+    Client client = createEchoClient();
+    await client.onOpen.first;
+
+    Completer c = new Completer();
+    var echos = [];
+    client.onMessage.listen((MessageEvent message) {
+      echos.add(message.data);
+      if (echos.length == 2) {
+        c.complete();
+      }
+    });
+    client.send('message1');
+    client.send('message2');
+
+    await c.future;
+    client.close();
+
+    expect(echos, equals(['message1', 'message2']));
+  });
+
+  test('client closing the connection', () async {
+    Client client = createEchoClient();
+    await client.onOpen.first;
+    client.close();
+    await client.onClose.first;
+  });
+
+  test('client closing the connection with code and reason', () async {
+    Client client = createEchoClient();
+    await client.onOpen.first;
+    client.close(4001, 'Custom close.');
+    CloseEvent event = await client.onClose.first;
+    expect(event.code, equals(4001));
+    expect(event.reason, equals('Custom close.'));
+  });
+
+  test('server closing the connection', () async {
+    Client client = createCorClient();
+    await client.onOpen.first;
+    client.send('close');
+    await client.onClose.first;
+  });
+
+  test('server closing the connection with code and reason', () async {
+    Client client = createCorClient();
+    await client.onOpen.first;
+    client.send('close::4001::Custom close.');
+    CloseEvent event = await client.onClose.first;
+    expect(event.code, equals(4001));
+    expect(event.reason, equals('Custom close.'));
+  });
+
+  test('handle failed connection', () async {
+    Client client = create404Client();
+    await client.onClose.first;
+  });
+}

--- a/test/sockjs_client_integration_test.dart.temp.html
+++ b/test/sockjs_client_integration_test.dart.temp.html
@@ -1,0 +1,1 @@
+<script type="application/dart" src="sockjs_client_integration_test.dart"></script>

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -1,0 +1,56 @@
+library tool.dev;
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dart_dev/dart_dev.dart' show dev, config;
+import 'package:dart_dev/util.dart' show TaskProcess, reporter;
+
+main(List<String> args) async {
+  // https://github.com/Workiva/dart_dev
+
+  config.analyze.entryPoints = ['example/', 'lib/', 'tool/'];
+  config.format.directories = ['example/', 'lib/', 'tool/'];
+
+  config.coverage
+    ..before = [_startServer]
+    ..after = [_stopServer];
+  config.test
+    ..before = [_startServer]
+    ..after = [_stopServer]
+    ..unitTests = []
+    ..integrationTests = ['test/sockjs_client_integration_test.dart']
+    ..platforms = ['content-shell', 'dartium'];
+
+  await dev(args);
+}
+
+/// Server needed for integration tests and examples.
+TaskProcess _server;
+
+/// Output from the server (only used if caching the output to dump at the end).
+List<String> _serverOutput;
+
+/// Start the server needed for integration tests and cache the server output
+/// until the task requiring the server has finished. Then, the server output
+/// will be dumped all at once.
+Future _startServer() async {
+  _serverOutput = [];
+  _server = new TaskProcess('node', ['tool/server.js']);
+  _server.stdout.listen(_serverOutput.add);
+  _server.stderr.listen(_serverOutput.add);
+  // todo: wait for server to start
+}
+
+/// Stop the server needed for integration tests.
+Future _stopServer() async {
+  if (_serverOutput != null) {
+    reporter.logGroup('HTTP Server Logs',
+        output: '    ${_serverOutput.join('\n')}');
+  }
+  if (_server != null) {
+    try {
+      _server.kill();
+    } catch (e) {}
+  }
+}

--- a/tool/server.js
+++ b/tool/server.js
@@ -1,0 +1,47 @@
+var http = require('http');
+var sockjs = require('sockjs');
+
+var sockjsUrl = '//cdn.jsdelivr.net/sockjs/1.0.3/sockjs.min.js';
+
+var echo = sockjs.createServer({
+    sockjs_url: sockjsUrl
+});
+echo.on('connection', function(conn) {
+    conn.on('data', function(message) {
+        console.log('[echo] "' + message + '"');
+        conn.write(message);
+    });
+    conn.on('close', function() {
+        console.log('[echo] closed.');
+    });
+});
+
+var closeOnRequest = sockjs.createServer({
+    sockjs_url: sockjsUrl
+});
+closeOnRequest.on('connection', function(conn) {
+    conn.on('data', function(message) {
+        if (message.substr(0, 'close'.length) === 'close') {
+            var parts = message.split('::');
+            var code;
+            var reason;
+            if (parts.length >= 2) {
+                code = parseInt(parts[1], 10);
+            }
+            if (parts.length >= 3) {
+                reason = parts[2];
+            }
+            console.log('[cor] close request received');
+            conn.close(code, reason);
+        }
+    });
+    conn.on('close', function() {
+        console.log('[cor] closed.');
+    });
+
+});
+
+var server = http.createServer();
+echo.installHandlers(server, {prefix: '/echo'});
+closeOnRequest.installHandlers(server, {prefix: '/cor'});
+server.listen(8000, 'localhost');


### PR DESCRIPTION
## Issue
- No way to close the SockJS client.
- No tests.
## Changes

**Source:**
- Add a `close([int code, String reason])` method to `Client`.
  - Calls `.close()` on the underlying `WebSocket` instance if `websocket` protocol is being used
  - Calls `._didClose()` on the `Client` if `xhr-streaming` protocol is being used

**Tests:**
- Integration tests added for..
  - default configuration (no protocol whitelist specified)
  - `websocket` protocol
  - `xhr-streaming` protocol
## Areas of Regression
- closing of underlying transport
## Testing
- `pub get && pub run dart_dev test`
## Code Review

@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 

fyi: @bryonmarks-wf @thieupham-wf @katiesullivan-wf 
