### PR TITLE
WP-4548 Release sockjs-dart-client 0.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sockjs-dart-client",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A SockJS client in Dart",
   "repository": {
     "type": "git",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name:  sockjs_client
-version: 0.3.2
+version: 0.3.3
 description:  A SockJS client in Dart
 homepage: https://github.com/nelsonsilva/sockjs-dart-client
 authors:


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/WP-4548

Releases that need to go out at the same time (if any):

JIRA and PR's included in this release:

======= sockjs-dart-client 0.3.3 items =======

WP-6538 - Dart 2 and DDC compatibility changes. - https://github.com/Workiva/sockjs-dart-client/pull/15

======= end =======

Diff Between Last Tag and Proposed Release: 0.3.2...release-0-3-3
