### PR TITLE
AF-88 release sockjs-dart-client 0.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sockjs-dart-client",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "A SockJS client in Dart",
   "repository": {
     "type": "git",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name:  sockjs_client
-version: 0.3.3
+version: 0.3.4
 description:  A SockJS client in Dart
 homepage: https://github.com/nelsonsilva/sockjs-dart-client
 authors:


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/AF-88

Releases that need to go out at the same time (if any):

JIRA and PR's included in this release:

======= sockjs-dart-client 0.3.4 items =======

AF-1874 - Dart 2 compatibility - https://github.com/Workiva/sockjs-dart-client/pull/18

======= end =======

Diff Between Last Tag and Proposed Release: 0.3.3...release-0-3-4
