### PR TITLE
remove defunct image from build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:350667 as build
+FROM google/dart:1.24.3 as build
+
+RUN curl -sL https://deb.nodesource.com/setup_9.x | bash - \
+  && apt-get install -y nodejs \
+  && curl -L https://www.npmjs.com/install.sh | sh
 
 ARG NPM_TOKEN
 ARG NPM_CONFIG__AUTH


### PR DESCRIPTION
Removing smithy-runner-generator.  It's a liability.

Testing: 

- ensure CI passes
- basic regression testing

@stevenosborne-wf @jeffhall-wk @charliekump-wf @robbecker-wf @todbachman-wf @patkujawa-wf 