### PR TITLE
Add comments to unblock Dart 2.12

### DIFF
--- a/example/echo.dart
+++ b/example/echo.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 library echo;
 
 import "dart:html";

--- a/test/sockjs_client_integration_test.dart
+++ b/test/sockjs_client_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 library sockjs_client.test.sockjs_client_test;
 

--- a/test/xhr_streaming_test.dart
+++ b/test/xhr_streaming_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 library sockjs_client.test.xhr_streaming_test;
 


### PR DESCRIPTION
Adds null safety opt-out comments to Dart entry points to prepare for Dart 2.12+
Please reach out to #support-client-plat with any questions.

[_Created by Sourcegraph batch change `Workiva/add_dart2_9_comments`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/add_dart2_9_comments)