### PR TITLE
Raise the Dart SDK minimum to at least 2.11.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/dart2_base_image:0.0.0-dart2.13.4 as build
+FROM drydock-prod.workiva.net/workiva/dart2_base_image:1
 
 RUN curl -sL https://deb.nodesource.com/setup_9.x | bash - \
   && apt-get install -y nodejs \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN echo "installing npm packages"
 RUN npm install
 RUN echo "Starting the script section" && \
     pub get && \
-    dart analyze lib example && \
+    dart analyze . && \
     tar czvf sockjs_client.pub.tgz LICENSE README.md pubspec.yaml analysis_options.yaml lib/ && \
     echo "script section completed"
 ARG BUILD_ARTIFACTS_BUILD=/build/pubspec.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/dart:1.24.3 as build
+FROM drydock-prod.workiva.net/workiva/dart2_base_image:0.0.0-dart2.13.4 as build
 
 RUN curl -sL https://deb.nodesource.com/setup_9.x | bash - \
   && apt-get install -y nodejs \
@@ -34,7 +34,7 @@ RUN echo "installing npm packages"
 RUN npm install
 RUN echo "Starting the script section" && \
     pub get && \
-    dartanalyzer lib example && \
+    dart analyze lib example && \
     tar czvf sockjs_client.pub.tgz LICENSE README.md pubspec.yaml analysis_options.yaml lib/ && \
     echo "script section completed"
 ARG BUILD_ARTIFACTS_BUILD=/build/pubspec.lock

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -50,7 +50,7 @@ linter:
     # http://dart-lang.github.io/linter/lints/always_specify_types.html
     # recommendation: optional
     # 0 issues
-    - always_specify_types
+#    - always_specify_types
 
     # Annotate overridden members.
     # http://dart-lang.github.io/linter/lints/annotate_overrides.html

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,9 +2,6 @@ name:  sockjs_client
 version: 0.3.6
 description:  A SockJS client in Dart
 homepage: https://github.com/nelsonsilva/sockjs-dart-client
-authors:
-- Nelson Silva <nelson.silva@inevo.pt>
-- Sébastien Deleuze
 
 environment:
   sdk: ">=2.11.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ authors:
 - Sébastien Deleuze
 
 environment:
-  sdk: '>=1.24.3<3.0.0'
+  sdk: ">=2.11.0 <3.0.0"
 
 dependencies:
   dart2_constant: ^1.0.0


### PR DESCRIPTION
## Overview
This updates the minimum Dart version that can be used to at least 2.11.0. Why 2.11.0 and not 2.13.4? Because setting it to 2.12.0 or higher opts the project into null safety (https://dart.dev/null-safety) which our code has not been migrated to yet. 
## What about null safety?
Once a project has been migrated to null safety it is ok to update the  minimum to 2.12.0 or even 2.13.4 since everyone at Workiva should be  using 2.13.4 now.
## Review / Testing / QA / Merge
If CI passes please review and merge. Most Dart CI has already been updated to run under 2.13.4 already so updating the minimum here doesn't change any code, or CI circumstances.
If CI fails, it's likely because an image in the Dockerfile or skynet.yaml is still running an older version of Dart. It should be updated to one with Dart 2.13. A list of existing 2.13 images lives here  https://wiki.atl.workiva.net/display/CP/Dart+2.13+Upgrade Feel free to fix CI and get this PR merged. However if you don't get to it, be aware that Client Platform will be going through the batch to help fix  any failures.
Please reach out to #support-client-plat with any questions.

[_Created by Sourcegraph batch change `Workiva/up_dart_sdk_minimum_to_2.11`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/up_dart_sdk_minimum_to_2.11)