### PR TITLE
Remove dart2_constant

### DIFF
--- a/.dart_tool/package_config.json
+++ b/.dart_tool/package_config.json
@@ -1,0 +1,488 @@
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "analyzer",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/analyzer-0.32.6",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "archive",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/archive-2.0.13",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "args",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/args-1.6.0",
+      "packageUri": "lib/",
+      "languageVersion": "2.3"
+    },
+    {
+      "name": "async",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/async-2.8.2",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "bazel_worker",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/bazel_worker-0.1.25",
+      "packageUri": "lib/",
+      "languageVersion": "2.3"
+    },
+    {
+      "name": "boolean_selector",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/boolean_selector-1.0.5",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "build",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/build-0.12.8",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "build_config",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/build_config-0.3.2",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "build_modules",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/build_modules-1.0.3",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "build_resolvers",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/build_resolvers-0.2.2+7",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "build_runner",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/build_runner-0.10.3",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "build_runner_core",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/build_runner_core-1.0.0",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "build_test",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/build_test-0.10.6",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "build_web_compilers",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/build_web_compilers-0.4.4+3",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "built_collection",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/built_collection-4.3.2",
+      "packageUri": "lib/",
+      "languageVersion": "2.6"
+    },
+    {
+      "name": "built_value",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/built_value-7.1.0",
+      "packageUri": "lib/",
+      "languageVersion": "2.3"
+    },
+    {
+      "name": "charcode",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/charcode-1.3.1",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "clock",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/clock-1.1.0",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "code_builder",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/code_builder-3.7.0",
+      "packageUri": "lib/",
+      "languageVersion": "2.7"
+    },
+    {
+      "name": "collection",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/collection-1.15.0",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "convert",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/convert-2.1.1",
+      "packageUri": "lib/",
+      "languageVersion": "1.17"
+    },
+    {
+      "name": "crypto",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/crypto-2.1.5",
+      "packageUri": "lib/",
+      "languageVersion": "2.3"
+    },
+    {
+      "name": "csslib",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/csslib-0.14.6+1",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "dart_style",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/dart_style-1.1.3",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "file",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/file-5.2.1",
+      "packageUri": "lib/",
+      "languageVersion": "2.2"
+    },
+    {
+      "name": "fixnum",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/fixnum-0.10.11",
+      "packageUri": "lib/",
+      "languageVersion": "2.1"
+    },
+    {
+      "name": "front_end",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/front_end-0.1.4+2",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "glob",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/glob-1.2.0",
+      "packageUri": "lib/",
+      "languageVersion": "2.1"
+    },
+    {
+      "name": "graphs",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/graphs-0.1.3+1",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "html",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/html-0.14.0",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "http",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/http-0.12.2",
+      "packageUri": "lib/",
+      "languageVersion": "2.4"
+    },
+    {
+      "name": "http_multi_server",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/http_multi_server-2.2.0",
+      "packageUri": "lib/",
+      "languageVersion": "2.1"
+    },
+    {
+      "name": "http_parser",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/http_parser-3.1.4",
+      "packageUri": "lib/",
+      "languageVersion": "2.3"
+    },
+    {
+      "name": "intl",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/intl-0.17.0",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "io",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/io-0.3.5",
+      "packageUri": "lib/",
+      "languageVersion": "2.1"
+    },
+    {
+      "name": "js",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/js-0.6.3",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "json_annotation",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/json_annotation-1.2.0",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "json_rpc_2",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/json_rpc_2-2.2.2",
+      "packageUri": "lib/",
+      "languageVersion": "2.2"
+    },
+    {
+      "name": "kernel",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/kernel-0.3.4+2",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "logging",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/logging-0.11.4",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "matcher",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/matcher-0.12.3+1",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "meta",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/meta-1.7.0",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "mime",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/mime-0.9.7",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "multi_server_socket",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/multi_server_socket-1.0.2",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "node_interop",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/node_interop-1.2.1",
+      "packageUri": "lib/",
+      "languageVersion": "2.9"
+    },
+    {
+      "name": "node_io",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/node_io-1.2.0",
+      "packageUri": "lib/",
+      "languageVersion": "2.2"
+    },
+    {
+      "name": "node_preamble",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/node_preamble-1.4.13",
+      "packageUri": "lib/",
+      "languageVersion": "1.24"
+    },
+    {
+      "name": "package_config",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/package_config-1.9.3",
+      "packageUri": "lib/",
+      "languageVersion": "2.7"
+    },
+    {
+      "name": "package_resolver",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/package_resolver-1.0.10",
+      "packageUri": "lib/",
+      "languageVersion": "2.1"
+    },
+    {
+      "name": "path",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/path-1.8.0",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "pedantic",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/pedantic-1.11.1",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "plugin",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/plugin-0.2.0+3",
+      "packageUri": "lib/",
+      "languageVersion": "1.0"
+    },
+    {
+      "name": "pool",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/pool-1.5.0",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "protobuf",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/protobuf-1.1.4",
+      "packageUri": "lib/",
+      "languageVersion": "2.7"
+    },
+    {
+      "name": "pub_semver",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/pub_semver-1.4.4",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "pubspec_parse",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/pubspec_parse-0.1.4",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "quiver",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/quiver-2.0.5",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "scratch_space",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/scratch_space-0.0.4+3",
+      "packageUri": "lib/",
+      "languageVersion": "2.9"
+    },
+    {
+      "name": "shelf",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/shelf-0.7.9",
+      "packageUri": "lib/",
+      "languageVersion": "2.1"
+    },
+    {
+      "name": "shelf_packages_handler",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/shelf_packages_handler-1.0.4",
+      "packageUri": "lib/",
+      "languageVersion": "1.22"
+    },
+    {
+      "name": "shelf_static",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/shelf_static-0.2.9+2",
+      "packageUri": "lib/",
+      "languageVersion": "2.3"
+    },
+    {
+      "name": "shelf_web_socket",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/shelf_web_socket-0.2.4+1",
+      "packageUri": "lib/",
+      "languageVersion": "2.1"
+    },
+    {
+      "name": "source_map_stack_trace",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/source_map_stack_trace-1.1.5",
+      "packageUri": "lib/",
+      "languageVersion": "1.8"
+    },
+    {
+      "name": "source_maps",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/source_maps-0.10.10",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "source_span",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/source_span-1.8.1",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "stack_trace",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/stack_trace-1.10.0",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "stream_channel",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/stream_channel-1.7.0",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "stream_transform",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/stream_transform-0.0.20",
+      "packageUri": "lib/",
+      "languageVersion": "2.6"
+    },
+    {
+      "name": "string_scanner",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/string_scanner-1.1.0",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "term_glyph",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/term_glyph-1.2.0",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "test",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/test-1.5.3",
+      "packageUri": "lib/",
+      "languageVersion": "2.1"
+    },
+    {
+      "name": "test_api",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/test_api-0.2.2",
+      "packageUri": "lib/",
+      "languageVersion": "2.1"
+    },
+    {
+      "name": "test_core",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/test_core-0.2.1+1",
+      "packageUri": "lib/",
+      "languageVersion": "2.1"
+    },
+    {
+      "name": "timing",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/timing-0.1.1+3",
+      "packageUri": "lib/",
+      "languageVersion": "2.2"
+    },
+    {
+      "name": "typed_data",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/typed_data-1.3.0",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "vm_service_client",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/vm_service_client-0.2.6+3",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "watcher",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/watcher-0.9.7+15",
+      "packageUri": "lib/",
+      "languageVersion": "2.2"
+    },
+    {
+      "name": "web_socket_channel",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/web_socket_channel-1.2.0",
+      "packageUri": "lib/",
+      "languageVersion": "2.10"
+    },
+    {
+      "name": "yaml",
+      "rootUri": "file:///root/.pub-cache/hosted/pub.dartlang.org/yaml-2.2.1",
+      "packageUri": "lib/",
+      "languageVersion": "2.4"
+    },
+    {
+      "name": "sockjs_client",
+      "rootUri": "../",
+      "packageUri": "lib/",
+      "languageVersion": "2.11"
+    }
+  ],
+  "generated": "2021-11-22T22:47:21.868973Z",
+  "generator": "pub",
+  "generatorVersion": "2.13.4"
+}

--- a/lib/sockjs_client.dart
+++ b/lib/sockjs_client.dart
@@ -4,10 +4,10 @@ import "dart:async";
 import "dart:html" as html;
 import "dart:js";
 
-import "package:dart2_constant/convert.dart" as convert;
 
 import "src/events.dart" as event;
 import "src/utils.dart" as utils;
+import 'dart:convert';
 
 part "src/ajax.dart";
 part "src/client.dart";

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -173,7 +173,7 @@ class Client extends Object with event.Emitter {
     case 'a':
       var s = data.substring(1);
       if (s == null) s = '[]';
-      var payload = convert.json.decode(s);
+      var payload = json.decode(s);
       for(var i=0; i < payload.length; i++){
           _dispatchMessage(payload[i]);
       }
@@ -181,13 +181,13 @@ class Client extends Object with event.Emitter {
     case 'm':
       var s = data.substring(1);
       if (s == null) s = 'null';
-      var payload = convert.json.decode(s);
+      var payload = json.decode(s);
       _dispatchMessage(payload);
       break;
     case 'c':
       var s = data.substring(1);
       if (s == null) s = '[]';
-      var payload = convert.json.decode(s);
+      var payload = json.decode(s);
       _didClose(payload[0], payload[1]);
       break;
     case 'h':

--- a/lib/src/info.dart
+++ b/lib/src/info.dart
@@ -67,7 +67,7 @@ class AjaxInfoReceiver extends InfoReceiver {
         tref = null;
         if (evt.status == 200) {
             var rtt = new DateTime.now().millisecondsSinceEpoch - t0;
-            var info = new Info.fromJSON(convert.json.decode(evt.text));
+            var info = new Info.fromJSON(json.decode(evt.text));
             dispatch(new InfoReceiverEvent("finish", info, rtt));
         } else {
             dispatch(new InfoReceiverEvent("finish"));
@@ -135,7 +135,7 @@ class WInfoReceiverIframe {
     var ir = new AjaxInfoReceiver(baseUrl, XHRLocalObjectFactory);
     ir.onFinish.listen( (event.Event evt) {
       if (evt is InfoReceiverEvent) {
-        ri._didMessage('m${convert.json.encode([evt.info, evt.rtt])}');
+        ri._didMessage('m${json.encode([evt.info, evt.rtt])}');
       }
       ri._didClose();
     });

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,9 +1,9 @@
 library utils;
 
+import 'dart:convert';
 import 'dart:math' as Math;
 import 'dart:html';
 
-import "package:dart2_constant/convert.dart" as convert;
 
 import "../sockjs_client.dart" as SockJS;
 
@@ -56,7 +56,7 @@ String amendUrl(String url) {
     return url;
 }
 
-closeFrame(code, reason) => 'c${convert.json.encode([code, reason])}';
+closeFrame(code, reason) => 'c${json.encode([code, reason])}';
 
 bool userSetCode(int code) => code == 1000 || (code >= 3000 && code <= 4999);
 
@@ -80,7 +80,7 @@ bool isSameOriginUrl(String url_a, [String url_b]) {
               == url_b.split('/').getRange(0,3).join('/'));
 }
 
-String quote(String string) => convert.json.encode(string);
+String quote(String string) => json.encode(string);
 
 const _all_protocols = const [
                        'websocket',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,6 @@ environment:
   sdk: ">=2.11.0 <3.0.0"
 
 dependencies:
-  dart2_constant: ^1.0.0
   logging: ">=0.9.0 <1.0.0"
 
 dev_dependencies:


### PR DESCRIPTION
Summary
---
Client Platform is updating dependencies! Read more details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This batch is to remove uses of dart2_constant which is a remnant from the dart 2 upgrade.

For more info, reach out to `#support-client-plat` on Slack.

[_Created by Sourcegraph batch change `Workiva/remove_dart2_constant`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/remove_dart2_constant)