### PR TITLE
Replace deprecated commands with new dart commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir /root/.ssh && \
 RUN echo "installing npm packages"
 RUN npm install
 RUN echo "Starting the script section" && \
-    pub get && \
+    dart pub get && \
     dart analyze . && \
     tar czvf sockjs_client.pub.tgz LICENSE README.md pubspec.yaml analysis_options.yaml lib/ && \
     echo "script section completed"

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -26,11 +26,11 @@ case $TASK in
     sleep 2
 
     if [[ $DART_VERSION = $DART_2_PREFIX* ]]; then
-      echo -e 'pub run build_runner test -- -P all -P travis'
-      pub run build_runner test -- -P all -P travis
+      echo -e 'dart run build_runner test -- -P all -P travis'
+      dart run build_runner test -- -P all -P travis
     else
-      echo -e 'pub run test -P all -P travis'
-      pub run test -P all -P travis
+      echo -e 'dart test -P all -P travis'
+      dart test -P all -P travis
     fi
 
     kill $SOCKJS_SERVER


### PR DESCRIPTION
This Sourcegraph batch replaces deprecated commands from the Dart SDK with the new ones.
All new CLI commands now live under the main `dart` executable. See this issue for the details
https://github.com/dart-lang/sdk/issues/46100

This PR might need to be checked or tweaked for possible errors in the arguments to 
`dart analyze` and `dart format` since they take slightly different arguments than the original.
In most cases for analyze all the arguments can be removed and it can just be `dart analyze`.

Some of the argument changes were difficult to match and replace in an automated way. Since
there are only a few places that might break, it'll be easier to let the batch create the PR
and then manually adjust them.

### Argument changes for dartfmt -> dart format
`-w` should be removed automatically since overwriting files is now the default. But, if you spot one, remove it.
`--dry-run` is not a supported argument now. Replace with `--set-exit-if-changed -o none`

repos that look like they will need updates for dart format
- abide
- abide_archived
- bender.dart
- unscripted (unused repo)

### Argument changes for dartanalyzer -> dart analyze
`--no-hints` and `--no-lints` are removed

repos that look like they will need updates for dart analyze
- user_analytics


### QA steps:

- CI passing is a great start since these commands are usually called in the dockerfile, shell scripts, or skynet
- Check the changeset and if there are scripts that are only run locally and not in CI, try running them locally to verify they work
- If the PR has changes to `dart analyze` or `dart format` check the arguments
- Lastly, look for replacements that matched in the wrong place and should be undone or fixed

[_Created by Sourcegraph batch change `Workiva/dart_commands`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/dart_commands)