### PR TITLE
Update references to the archived slack room #support-client-plat

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 ## Review
 _[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._
 
-  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)
+  <!-- If you're making a PR from outside of the Frontend Architecture team, then first off, thanks! :)
 
         For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!
 
@@ -36,7 +36,7 @@ Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->
 
 ## Merge Checklist
 While we perform many automated checks before auto-merging, some manual checks are needed:
-- [ ] A Client Platform member has reviewed these changes
+- [ ] A Frontend Architecture member has reviewed these changes
 - [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
 - [ ] _For release PRs -_ Version metadata in Rosie comment is correct
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,7 @@ _[See CONTRIBUTING.md][contributing-review-types] for more details on review typ
             *** Please refrain from tagging the whole team to prevent extraneous notifications. ***
 
             If you're not sure who from our team should review these changes, then leave this section
-            blank for now and post a link to the PR in the #support-client-plat Slack channel.
+            blank for now and post a link to the PR in the #support-frontend-architecture Slack channel.
 
   -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Have a bug to report or an improvement/feature to request? Please
 the issue template with as much detail as necessary.
 
 ###### Workiva Employees
-> __Contact us on Slack:__ [\#support-client-plat](https://workiva.slack.com/app_redirect?channel=support-client-plat)
+> __Contact us on Slack:__ [\#support-frontend-architecture](https://workiva.slack.com/app_redirect?channel=support-frontend-architecture)
 
 Have a bug to report or an improvement/feature to request?
 Please contact us on Slack or [create a JIRA ticket](https://jira.atl.workiva.net/secure/CreateIssue!default.jspa?pid=CPLAT&component=sockjs-dart-client)


### PR DESCRIPTION
This batch changes references to the archived support-client-plat slack channel to now reference the support-frontend-architecture channel.

`replace "#support-client-plat" "#support-frontend-architecture"`

### QA steps:

CI passing should be sufficient as these changes are documentation changes.

[_Created by Sourcegraph batch change `Workiva/update_slack_channel_fea`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/update_slack_channel_fea)